### PR TITLE
strip-any-prefix default to false

### DIFF
--- a/ekglib/xlsx_parser/parser.py
+++ b/ekglib/xlsx_parser/parser.py
@@ -90,7 +90,7 @@ def strip_common_prefix_in_column(df, column_name):
         return df
     if some_prefix.startswith('http://') or some_prefix.startswith('https://'):
         return df
-    log_item('Strip prefix', some_prefix)
+    log_item(f'Strip prefix from \'{column_name}\'', some_prefix)
     #
     # Don't touch date columns
     #

--- a/ekglib/xlsx_parser/parser.py
+++ b/ekglib/xlsx_parser/parser.py
@@ -529,7 +529,7 @@ def main():
     args.add_argument(
         '--strip-any-prefix',
         help='Strip any prefix from any column if all cells in that column have the same prefix',
-        default=True
+        default=False
     )
     args.add_argument(
         '--ignored-values', help='A list of values to ignore',


### PR DESCRIPTION
pending confirmation from @mbarbieri77 that it worked for him. 
@jgeluk 
![image](https://user-images.githubusercontent.com/6841417/97217957-e9954b80-17bf-11eb-8abf-e37978b36089.png) by 'should probably remove this feature'. did you mean the toggle to turn off magic prefix stripping (which wouldn't have worked), or the magic prefix stripping itself?
